### PR TITLE
fix(Metrics): don't calculate s-score on a rolling basis by default

### DIFF
--- a/src/krisi/evaluate/library/default_metrics_classification.py
+++ b/src/krisi/evaluate/library/default_metrics_classification.py
@@ -175,6 +175,7 @@ s_score = Metric[float](
     plot_funcs_rolling=(display_time_series, dict(width=1500.0)),
     accepts_probabilities=False,
     supports_multiclass=False,
+    calculation=Calculation.single,
     purpose=Purpose.objective,
 )
 """~"""


### PR DESCRIPTION
Closes #